### PR TITLE
Implement Base-89 Encoding

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "import",
     "jest"
   ],
+  "ignorePatterns": ["**/dist/*"],
   "rules": {
     "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/no-unused-vars": "error",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # los-token
 
-Los, or `los-token`, is a small, deliberately feature-light identity token system. Its primary use case is for bare-bones session validation, particularly in cases where egress data comes at a premium and every byte sent over the wire counts. Los prioritizes compactness, sacrificing the advanced functionality and customizability of JWTs in favor of simple code, fast runtimes, and small token sizes. Generated tokens contain only a user id field, an expiration field, and a hash, in that order, and take the form of period-delimited hexadecimal blocks. Los uses the [BLAKE2](https://www.blake2.net/) suite of cryptographic functions for hashing, and defaults to its 64-bit, multicore variant, BLAKE2bp.
+Los, or `los-token`, is a small, deliberately feature-light identity token system. Its primary use case is for bare-bones session validation, particularly in applications where egress data comes at a premium and every byte sent over the wire counts. Los prioritizes compactness, sacrificing the advanced functionality and customizability of JWTs in favor of simple code, short runtimes, and small token sizes. Generated tokens contain only an ID field, an expiration field, and a hash, in that order, and take the form of period-delimited blocks encoded into a base-89, cookie-compliant character set (as defined by [RFC6265](https://datatracker.ietf.org/doc/html/rfc6265#page-9)). Los uses the [BLAKE2](https://www.blake2.net/) suite of cryptographic functions for hashing, and defaults to its 64-bit, multicore variant, BLAKE2bp.
 
 # Usage
 
@@ -52,4 +52,4 @@ When validation fails, it will either use a native `Error` type or one of the fo
 - **`SignatureError`** - The hash calculated during validation doesn’t match the token’s included hash value.
 - **`ExpirationError`** - The token’s `expires` value refers to a timestamp in the past.
 
-To make checking whether an error is a Los-specific error more succinct, all Los-specific error types are extensions of a base type `LosError`, which is itself an extension of the native `Error` type.
+To aid in determining whether an error is a Los-specific error, all Los-specific error types are extensions of a base type `LosError`, which is itself an extension of the native `Error` type.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5946,9 +5946,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -12922,9 +12922,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "los-token",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "blake2": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "jest --config jestconfig.json",
+    "test": "jest --config jestconfig.json --runInBand",
     "build": "tsc",
     "format": "prettier --write 'src/**/*.ts'",
     "lint": "eslint --fix src/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "los-token",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Lightweight, minimal session tokens using BLAKE2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/bases.test.ts
+++ b/src/__tests__/bases.test.ts
@@ -1,0 +1,58 @@
+import {
+  decToB89,
+  b89ToDec,
+  strToB89,
+  b89ToStr,
+  bufToB89,
+  b89ToBuf,
+} from '../bases';
+
+describe('Decimal values are properly encoded', () => {
+  const initial = 123456789;
+  const encoded = decToB89(initial);
+  const decoded = b89ToDec(encoded);
+  test('encodes to the expected value', () => {
+    expect(encoded).toBe('B|LA_');
+  });
+  test('decodes back to the initial value', () => {
+    const castDecoded = Number(decoded);
+    expect(castDecoded).toBe(initial);
+  });
+});
+
+describe('BigInt values are properly encoded', () => {
+  const initial = 1234567891011121314n;
+  const encoded = decToB89(initial);
+  const decoded = b89ToDec(encoded);
+  test('encodes to the expected value', () => {
+    expect(encoded).toBe('Du22v03RKY');
+  });
+  it('decodes back to the initial value', () => {
+    expect(decoded).toBe(initial);
+  });
+});
+
+describe('String values are properly encoded', () => {
+  const initial = 'LosToken: Fun for the whole family! 👨‍👩‍👧‍👦';
+  const encoded = strToB89(initial);
+  const decoded = b89ToStr(encoded);
+  test('encodes to the expected value', () => {
+    expect(encoded).toBe('Br9U*H[7Q^X~ivKUArNS2yV=c!Dz*\'>4N#T1ML|irX^+fl4TR2MwzC8!gLi3?`H(Rcv`{e#3j7~/');
+  });
+  test('decodes back to the initial value', () => {
+    expect(decoded).toBe(initial);
+  });
+});
+
+describe('Buffer values are properly encoded', () => {
+  const initial = 'I dunno; I\'m just, like, tossin\' strings into the function, bro.';
+  const inputBuffer = Buffer.from(initial);
+  const encoded = bufToB89(inputBuffer);
+  const decoded = b89ToBuf(encoded);
+  test('encodes to the expected value', () => {
+    expect(encoded).toBe('h`HN~BbW7<zu?oq?U/A-vS@O2V--Sy-vwqF7#]:O3`O<#dbbCZ-7!bsauo@b%<`t$5&Hf$]Z8`AhU3(');
+  });
+  test('decodes back to the initial value', () => {
+    expect(decoded.toString('hex')).toBe(inputBuffer.toString('hex'));
+  });
+});

--- a/src/__tests__/bases.test.ts
+++ b/src/__tests__/bases.test.ts
@@ -27,7 +27,7 @@ describe('BigInt values are properly encoded', () => {
   test('encodes to the expected value', () => {
     expect(encoded).toBe('Du22v03RKY');
   });
-  it('decodes back to the initial value', () => {
+  test('decodes back to the initial value', () => {
     expect(decoded).toBe(initial);
   });
 });

--- a/src/__tests__/los.test.ts
+++ b/src/__tests__/los.test.ts
@@ -19,7 +19,7 @@ const tokenGeneratorDifferentKey = new Los(`${key.slice(0, -1)}0`, salt);
 const tokenGeneratorDifferentSalt = new Los(key, `${salt.slice(0, -1)}v`);
 
 // Each of the sets in the patterns below is identical and reflects the legal characters in an
-// RFC6265 cookie-octet.
+// RFC6265 cookie-octet, excluding period, which is used as the delimiter.
 const tokenPatternString = /0([\w!#-+\-/:<-@[\]^`{-~]+\.){2}[\w!#-+\-/:<-@[\]^`{-~]+/gi;
 const tokenPatternNumeric = /1([\w!#-+\-/:<-@[\]^`{-~]+\.){2}[\w!#-+\-/:<-@[\]^`{-~]+/gi;
 

--- a/src/__tests__/los.test.ts
+++ b/src/__tests__/los.test.ts
@@ -18,8 +18,10 @@ const tokenGeneratorBigInt = new Los(key, salt, {
 const tokenGeneratorDifferentKey = new Los(`${key.slice(0, -1)}0`, salt);
 const tokenGeneratorDifferentSalt = new Los(key, `${salt.slice(0, -1)}v`);
 
-const tokenPatternString = /0[0-9a-f]+.[0-9a-f]+.[0-9a-f]+/gi;
-const tokenPatternNumeric = /1[0-9a-f]+.[0-9a-f]+.[0-9a-f]+/gi;
+// Each of the sets in the patterns below is identical and reflects the legal characters in an
+// RFC6265 cookie-octet.
+const tokenPatternString = /0([\w!#-+\-/:<-@[\]^`{-~]+\.){2}[\w!#-+\-/:<-@[\]^`{-~]+/gi;
+const tokenPatternNumeric = /1([\w!#-+\-/:<-@[\]^`{-~]+\.){2}[\w!#-+\-/:<-@[\]^`{-~]+/gi;
 
 describe('Sign correctly handles timestamp variations', () => {
   test('Sign succeeds with default timestamp', () => {
@@ -133,7 +135,7 @@ describe('Validate correctly handles invalid tokens', () => {
   });
 
   test('Validate fails when signature is changed', () => {
-    const alteredSignatureToken = [splitToken[0], splitToken[1], splitToken[2].replace(/[0-9a-f]/gi, 'a')].join('.');
+    const alteredSignatureToken = [splitToken[0], splitToken[1], splitToken[2].replace(/./gi, 'a')].join('.');
     expect(() => tokenGenerator.validate(alteredSignatureToken)).toThrow(SignatureError);
   });
 

--- a/src/bases.ts
+++ b/src/bases.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-bitwise */
+import { TextEncoder, TextDecoder } from 'util';
+
+// Create an encoding scheme that uses only cookie-safe characters as defined in RFC6265 https://datatracker.ietf.org/doc/html/rfc6265.
+const c = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&'()*+-/:<=>?@[]^_`{|}~";
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export const decToB89 = (dec: number | bigint): string => {
+  let b = BigInt(dec);
+  let s = '';
+  do {
+    s = c[Number(b % 89n)] + s;
+    b /= 89n;
+  } while (b !== 0n);
+  return s;
+};
+
+export const b89ToDec = (b89: string): bigint => {
+  let m = 1n;
+  let v = 0n;
+  for (let i = b89.length; i > 0; i -= 1, m *= 89n) {
+    v += BigInt(c.indexOf(b89[i - 1])) * m;
+  }
+  return v;
+};
+
+const bytesToB89 = (bytes: Uint8Array): string => {
+  let b = 0n;
+  for (let i = 0; i < bytes.length; i += 1) {
+    b <<= 8n;
+    b |= BigInt(bytes[i]);
+  }
+  return decToB89(b);
+};
+
+const b89ToBytes = (b89: string): Uint8Array => {
+  let b = b89ToDec(b89);
+  const bytes = [];
+  while (b > 0n) {
+    bytes.unshift(Number(b & 255n));
+    b >>= 8n;
+  }
+  return Uint8Array.from(bytes);
+};
+
+export const strToB89 = (str: string): string => {
+  const bytes = encoder.encode(str);
+  return bytesToB89(bytes);
+};
+
+export const b89ToStr = (b89: string): string => {
+  const bytes = b89ToBytes(b89);
+  return decoder.decode(bytes);
+};
+
+export const bufToB89 = (buf: Buffer): string => {
+  const bytes = new Uint8Array(buf);
+  return bytesToB89(bytes);
+};
+
+export const b89ToBuf = (b89: string): Buffer => {
+  const bytes = b89ToBytes(b89);
+  return Buffer.from(bytes.buffer);
+};


### PR DESCRIPTION
## Summary

Tokens now use a much more efficient, base-89 (enneaoctogesimal) encoding system in place of the original hexadecimal scheme. Generated tokens are still valid as cookies using the new system, per [RFC6265](https://datatracker.ietf.org/doc/html/rfc6265#page-9). The examples below demonstrate the typical reduction in token size that can be expected using the new encoding. Closes #4.

## Numeric

```typescript
const tokenGenerator = new Los('abcd', 'efgh');
tokenGenerator.sign(12345678n);
```

| Version | Output |
| ------- | ------ |
| 1.0.1   | `1bc614e.615d65c3.e3a15952d1dc335db7e64d1caeaa3b832c2ae16e7ca1e1cc4d807d2d55f9d5b7` |
| 2.0.0   | ``1Rt1r.aDMax.GU!@j@u6~0@#r>Yq>E*24qm#!u!3gP'@_//W`B#&`` |

## String

```typescript
const tokenGenerator = new Los('abcd', 'efgh');
tokenGenerator.sign('LosToken');
```

| Version | Output |
| ------- | ------ |
| 1.0.1   | `04c6f73546f6b656e.615d65c3.7136431411ba039cc9e7df63fde49d42ca8b00be586834b8ac97b53f3f946dff` |
| 2.0.0   | `0P$Kjo~lEP&.aDMfp.BnG>4'0QU/3ErPCo%Zg%h\|drP&y{pFV5}tDmwqp#` |